### PR TITLE
chore: Update CODEOWNERS for pnpm/uv migration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 * @cloudquery/cloudquery-framework
 
-package-lock.json
+pnpm-lock.yaml
 package.json
 .release-please-manifest.json
 CHANGELOG.md


### PR DESCRIPTION
Update CODEOWNERS to reference pnpm-lock.yaml instead of package-lock.json.